### PR TITLE
Feature/process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
         "react-icons": "^5.5.0",
         "react-router": "^7.6.2",
         "react-router-dom": "^7.6.2",
-        "sqlite3": "^5.1.7",
-        "win32-api": "^26.1.2"
+        "sqlite3": "^5.1.7"
       },
       "devDependencies": {
         "@electron-toolkit/eslint-config-prettier": "^3.0.0",
@@ -6492,15 +6491,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@waiting/shared-types": {
-      "version": "23.24.0",
-      "resolved": "https://registry.npmjs.org/@waiting/shared-types/-/shared-types-23.24.0.tgz",
-      "integrity": "sha512-E7U3ulMbHiT05Jd8RlepovGeixCQMAdJMkGE83s/JMtCOx0n02Ss7OURLVgV+j06SeHZ52wCBoHfriqlW6Pa3w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -13259,13 +13249,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/koffi": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.12.2.tgz",
-      "integrity": "sha512-OlHr5pjRfzauBYHxj/yPgw8AEaSzGxzOmkSKks38mc3j5OcK1TJ3VAGgt0qAw1j1Y0rLnXZRsoG79vTELNbj1A==",
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
@@ -18547,31 +18530,6 @@
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/win32-api": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/win32-api/-/win32-api-26.1.2.tgz",
-      "integrity": "sha512-6pFihEkolpU8PIPk3pbBa/Wn2S9esHAbRrlvRObKRARMdXb2dpe50J5FRApOhK8HCbyI4/uS6qtxZ/hKpr+8Kw==",
-      "license": "MIT",
-      "dependencies": {
-        "win32-def": "^26.1.2"
-      },
-      "engines": {
-        "node": ">=20.11.0"
-      }
-    },
-    "node_modules/win32-def": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/win32-def/-/win32-def-26.1.2.tgz",
-      "integrity": "sha512-vk65D1jZt6t0cTpP8fdUPbHobneOKPyYpk8ADIjUTq4aDkfNiHtbIAPqz/bqYABFZqRU7NCREqf5v7EOz3lstg==",
-      "license": "MIT",
-      "dependencies": {
-        "@waiting/shared-types": "^23.24.0",
-        "koffi": "^2.9.2"
-      },
-      "engines": {
-        "node": ">=18.11.0"
       }
     },
     "node_modules/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "react-icons": "^5.5.0",
         "react-router": "^7.6.2",
         "react-router-dom": "^7.6.2",
-        "sqlite3": "^5.1.7"
+        "sqlite3": "^5.1.7",
+        "win32-api": "^26.1.2"
       },
       "devDependencies": {
         "@electron-toolkit/eslint-config-prettier": "^3.0.0",
@@ -6492,6 +6493,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@waiting/shared-types": {
+      "version": "23.24.0",
+      "resolved": "https://registry.npmjs.org/@waiting/shared-types/-/shared-types-23.24.0.tgz",
+      "integrity": "sha512-E7U3ulMbHiT05Jd8RlepovGeixCQMAdJMkGE83s/JMtCOx0n02Ss7OURLVgV+j06SeHZ52wCBoHfriqlW6Pa3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
@@ -10412,9 +10422,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13241,6 +13251,13 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/koffi": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.12.2.tgz",
+      "integrity": "sha512-OlHr5pjRfzauBYHxj/yPgw8AEaSzGxzOmkSKks38mc3j5OcK1TJ3VAGgt0qAw1j1Y0rLnXZRsoG79vTELNbj1A==",
+      "hasInstallScript": true,
+      "license": "MIT"
     },
     "node_modules/lazy-val": {
       "version": "1.0.5",
@@ -18523,6 +18540,31 @@
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/win32-api": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/win32-api/-/win32-api-26.1.2.tgz",
+      "integrity": "sha512-6pFihEkolpU8PIPk3pbBa/Wn2S9esHAbRrlvRObKRARMdXb2dpe50J5FRApOhK8HCbyI4/uS6qtxZ/hKpr+8Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "win32-def": "^26.1.2"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/win32-def": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/win32-def/-/win32-def-26.1.2.tgz",
+      "integrity": "sha512-vk65D1jZt6t0cTpP8fdUPbHobneOKPyYpk8ADIjUTq4aDkfNiHtbIAPqz/bqYABFZqRU7NCREqf5v7EOz3lstg==",
+      "license": "MIT",
+      "dependencies": {
+        "@waiting/shared-types": "^23.24.0",
+        "koffi": "^2.9.2"
+      },
+      "engines": {
+        "node": ">=18.11.0"
       }
     },
     "node_modules/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^4.0.0",
         "@prisma/client": "^6.10.1",
+        "csv-parse": "^6.1.0",
         "electron-store": "^10.1.0",
         "electron-updater": "^6.3.9",
         "file-type": "^21.0.0",
@@ -8489,6 +8490,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.1.0.tgz",
+      "integrity": "sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==",
       "license": "MIT"
     },
     "node_modules/daisyui": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "react-icons": "^5.5.0",
     "react-router": "^7.6.2",
     "react-router-dom": "^7.6.2",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "win32-api": "^26.1.2"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^4.0.0",
     "@prisma/client": "^6.10.1",
+    "csv-parse": "^6.1.0",
     "electron-store": "^10.1.0",
     "electron-updater": "^6.3.9",
     "file-type": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "react-icons": "^5.5.0",
     "react-router": "^7.6.2",
     "react-router-dom": "^7.6.2",
-    "sqlite3": "^5.1.7",
-    "win32-api": "^26.1.2"
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,15 +1,11 @@
 import { app, shell, BrowserWindow, ipcMain } from "electron"
 import { join } from "path"
 import { electronApp, optimizer, is } from "@electron-toolkit/utils"
-import Store from "electron-store"
 import icon from "../../build/icon.ico?asset"
 import { registerAllHandlers } from "./registerHandlers"
 import { registerWindowHandler } from "./ipcHandlers/windowsHandler"
 import { logger } from "./utils/logger"
 import { ProcessMonitorService } from "./service/processMonitorService"
-
-// 設定ストア
-const store = new Store()
 
 function createWindow(): void {
   // Create the browser window.
@@ -69,16 +65,11 @@ app.whenReady().then(() => {
 
   createWindow()
 
-  // 自動ゲーム検出設定を確認してプロセス監視を開始
+  // プロセス監視を開始（自動ゲーム検出設定に関係なく）
   setTimeout(async () => {
-    const autoTracking = store.get("autoTracking", true) as boolean
-    if (autoTracking) {
-      const monitor = ProcessMonitorService.getInstance()
-      await monitor.startMonitoring()
-      logger.info("アプリケーション起動時にプロセス監視を自動開始しました")
-    } else {
-      logger.info("自動ゲーム検出が無効のため、プロセス監視の自動開始をスキップしました")
-    }
+    const monitor = ProcessMonitorService.getInstance()
+    await monitor.startMonitoring()
+    logger.info("アプリケーション起動時にプロセス監視を開始しました")
   }, 2000) // 2秒後に開始（UIの初期化を待つ）
 
   app.on("activate", function () {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,7 +69,7 @@ app.whenReady().then(() => {
 
   createWindow()
 
-  // 自動計測設定を確認してプロセス監視を開始
+  // 自動ゲーム検出設定を確認してプロセス監視を開始
   setTimeout(async () => {
     const autoTracking = store.get("autoTracking", true) as boolean
     if (autoTracking) {
@@ -77,7 +77,7 @@ app.whenReady().then(() => {
       await monitor.startMonitoring()
       logger.info("アプリケーション起動時にプロセス監視を自動開始しました")
     } else {
-      logger.info("自動計測が無効のため、プロセス監視を開始しませんでした")
+      logger.info("自動ゲーム検出が無効のため、プロセス監視の自動開始をスキップしました")
     }
   }, 2000) // 2秒後に開始（UIの初期化を待つ）
 

--- a/src/main/ipcHandlers/settingsHandlers.ts
+++ b/src/main/ipcHandlers/settingsHandlers.ts
@@ -37,7 +37,7 @@ export function registerSettingsHandlers(): void {
       const processMonitor = ProcessMonitorService.getInstance()
       processMonitor.updateAutoTracking(enabled)
 
-      logger.info(`自動ゲーム検出設定を更新しました: ${enabled ? "有効" : "無効"} (即座に反映)`)
+      logger.info(`自動ゲーム検出設定を更新: ${enabled ? "有効" : "無効"}`)
 
       return { success: true }
     } catch (error) {

--- a/src/main/ipcHandlers/settingsHandlers.ts
+++ b/src/main/ipcHandlers/settingsHandlers.ts
@@ -4,7 +4,7 @@
  * このファイルは、フロントエンドとメインプロセス間での設定同期機能を提供します。
  *
  * 主な機能：
- * - 自動計測設定の更新通知
+ * - 自動ゲーム検出設定の更新通知
  * - プロセス監視の動的制御
  * - 設定変更のリアルタイム反映
  */
@@ -13,40 +13,46 @@ import { ipcMain } from "electron"
 import Store from "electron-store"
 import { ApiResult } from "../../types/result"
 import { logger } from "../utils/logger"
+import ProcessMonitorService from "../service/processMonitorService"
 
 const store = new Store()
 
 export function registerSettingsHandlers(): void {
   /**
-   * 自動計測設定の更新ハンドラー
+   * 自動ゲーム検出設定の更新ハンドラー
    *
-   * フロントエンドから自動計測設定の変更を受け取り、
+   * フロントエンドから自動ゲーム検出設定の変更を受け取り、
    * メインプロセスの設定を更新します。
-   * 設定は次回アプリケーション起動時に反映されます。
+   * 設定は即座に反映されます。
    *
-   * @param enabled 自動計測を有効にするかどうか
+   * @param enabled 自動ゲーム検出を有効にするかどうか
    * @returns ApiResult 更新結果
    */
   ipcMain.handle("update-auto-tracking", async (_event, enabled: boolean): Promise<ApiResult> => {
     try {
       // electron-storeに設定を保存
       store.set("autoTracking", enabled)
-      logger.info(`自動計測設定を更新しました: ${enabled ? "有効" : "無効"} (次回起動時に反映)`)
+
+      // ProcessMonitorServiceにリアルタイムで設定を反映
+      const processMonitor = ProcessMonitorService.getInstance()
+      processMonitor.updateAutoTracking(enabled)
+
+      logger.info(`自動ゲーム検出設定を更新しました: ${enabled ? "有効" : "無効"} (即座に反映)`)
 
       return { success: true }
     } catch (error) {
-      logger.error("自動計測設定の更新に失敗:", error)
+      logger.error("自動ゲーム検出設定の更新に失敗:", error)
       return {
         success: false,
-        message: "自動計測設定の更新に失敗しました"
+        message: "自動ゲーム検出設定の更新に失敗しました"
       }
     }
   })
 
   /**
-   * 自動計測設定の取得ハンドラー
+   * 自動ゲーム検出設定の取得ハンドラー
    *
-   * メインプロセスの自動計測設定を取得します。
+   * メインプロセスの自動ゲーム検出設定を取得します。
    *
    * @returns ApiResult<boolean> 現在の設定値
    */
@@ -58,10 +64,10 @@ export function registerSettingsHandlers(): void {
         data: autoTracking
       }
     } catch (error) {
-      logger.error("自動計測設定の取得に失敗:", error)
+      logger.error("自動ゲーム検出設定の取得に失敗:", error)
       return {
         success: false,
-        message: "自動計測設定の取得に失敗しました"
+        message: "自動ゲーム検出設定の取得に失敗しました"
       }
     }
   })

--- a/src/main/service/processMonitorService.ts
+++ b/src/main/service/processMonitorService.ts
@@ -88,7 +88,7 @@ export class ProcessMonitorService extends EventEmitter {
     return ProcessMonitorService.instance
   }
 
-  private addGameInternal(gameId: string, gameTitle: string, exePath: string): void {
+  private addMonitoredGame(gameId: string, gameTitle: string, exePath: string): void {
     const exeName = path.basename(exePath)
     const game: MonitoredGame = {
       gameId,
@@ -511,7 +511,7 @@ export class ProcessMonitorService extends EventEmitter {
 
         // プロセスが実行中の場合、監視対象に追加
         if (isRunning) {
-          this.addGameInternal(game.id, game.title, game.exePath)
+          this.addMonitoredGame(game.id, game.title, game.exePath)
         }
       }
     } catch (error) {
@@ -547,6 +547,18 @@ export class ProcessMonitorService extends EventEmitter {
               relax_quotes: true,
               skip_empty_lines: true
             })
+
+            // 正しくパースされたかを検証
+            if (
+              !Array.isArray(records) ||
+              records.length === 0 ||
+              !Array.isArray(records[0]) ||
+              records[0].length < 3
+            ) {
+              logger.warn(`Invalid CSV line: ${line}`)
+              return undefined
+            }
+
             const [name, pidStr, fullPath] = records[0]
             const pid = parseInt(pidStr, 10)
 

--- a/src/main/service/processMonitorService.ts
+++ b/src/main/service/processMonitorService.ts
@@ -19,17 +19,12 @@
  * ```
  */
 
-import psList from "ps-list"
+import { EnumWindows } from "win32-api/util"
+import path from "path"
 import { EventEmitter } from "events"
 import Store from "electron-store"
 import { prisma } from "../db"
 import { logger } from "../utils/logger"
-import path from "path"
-import { exec } from "child_process"
-import { promisify } from "util"
-import * as iconv from "iconv-lite"
-
-const execAsync = promisify(exec)
 
 /**
  * 監視対象のゲーム情報

--- a/src/renderer/src/components/GeneralSettings.tsx
+++ b/src/renderer/src/components/GeneralSettings.tsx
@@ -8,7 +8,7 @@
  * - デフォルトソート順の設定
  * - デフォルトフィルター状態の設定
  * - オフラインモードの設定
- * - 起動時の自動計測の設定
+ * - 自動ゲーム検出の設定
  * - 設定の永続化
  * - リアルタイムでの変更反映
  *
@@ -38,7 +38,7 @@ import type { SortOption, FilterOption } from "src/types/menu"
  * 一般設定コンポーネント
  *
  * テーマ選択、デフォルトソート順、デフォルトフィルター状態、
- * オフラインモード、起動時の自動計測など、アプリケーションの一般的な設定を提供します。
+ * オフラインモード、自動ゲーム検出など、アプリケーションの一般的な設定を提供します。
  *
  * @returns 一般設定コンポーネント要素
  */
@@ -73,7 +73,7 @@ export default function GeneralSettings(): React.JSX.Element {
     }
   }
 
-  // 自動計測変更ハンドラー
+  // 自動ゲーム検出変更ハンドラー
   const handleAutoTrackingChange = async (enabled: boolean): Promise<void> => {
     setAutoTracking(enabled)
 
@@ -82,15 +82,15 @@ export default function GeneralSettings(): React.JSX.Element {
       const result = await window.api.settings.updateAutoTracking(enabled)
       if (result.success) {
         if (enabled) {
-          toast.success("起動時の自動計測を有効にしました（次回起動時に反映）")
+          toast.success("自動ゲーム検出を有効にしました")
         } else {
-          toast.success("起動時の自動計測を無効にしました（次回起動時に反映）")
+          toast.success("自動ゲーム検出を無効にしました")
         }
       } else {
         toast.error("設定の更新に失敗しました")
       }
     } catch (error) {
-      console.error("自動計測設定の更新エラー:", error)
+      console.error("自動ゲーム検出設定の更新エラー:", error)
       toast.error("設定の更新に失敗しました")
     }
   }
@@ -166,7 +166,7 @@ export default function GeneralSettings(): React.JSX.Element {
                 </label>
               </div>
 
-              {/* 自動計測 */}
+              {/* 自動ゲーム検出 */}
               <div className="form-control">
                 <label className="label cursor-pointer justify-start p-0">
                   <input
@@ -176,9 +176,11 @@ export default function GeneralSettings(): React.JSX.Element {
                     onChange={(e) => handleAutoTrackingChange(e.target.checked)}
                   />
                   <div>
-                    <span className="label-text font-medium">起動時の自動計測</span>
+                    <span className="label-text font-medium">自動ゲーム検出</span>
                     <p className="text-xs text-base-content/50 mt-1">
-                      {autoTracking ? "ゲーム起動時に自動計測開始" : "手動で自動検出の開始が必要"}
+                      {autoTracking
+                        ? "実行中ゲームを自動検出して監視開始"
+                        : "手動でのゲーム登録のみ"}
                     </p>
                   </div>
                 </label>


### PR DESCRIPTION
やったことまとめ

- win32-apiはプロセス一覧を取れなさそうだったのでなしに
- ffi-napiはnodeのバージョンが合わないため使えず
- キャッシュは不要だったので削除
- csvパースはライブラリで実行
- 自動検出の仕組みを変更 設定からのオンだけで実行
- オフのときはステータスバーを非表示に
- 多すぎるログを整理